### PR TITLE
支持 minPixelValue 参数

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "test": "node ./test"
   },
+  "files": [
+    "src"
+  ],
   "author": "Spikef",
   "license": "MIT",
   "dependencies": {

--- a/src/lib/convert.web.js
+++ b/src/lib/convert.web.js
@@ -5,6 +5,7 @@ module.exports = function(opts) {
     return function(decl) {
         // convert relative length unit to rem
         decl.value = decl.value.replace(relLenUnit, function($0, $1) {
+            if (+$1 < opt.minPixelValue) return $0;
             return calcValue($1, opts.remUnit, opts.remPrecision);
         });
 


### PR DESCRIPTION
[weex-vue-render](https://github.com/weexteam/weex-vue-render#pack-your-vue-file-to-webbundlejs) 的 1.x 版本打包 vue 的时候需要 [postcss-plugin-px2rem](https://github.com/ant-tool/postcss-plugin-px2rem) 插件
参考：https://github.com/ant-tool/postcss-plugin-px2rem#configuration
通过设置 `minPixelValue: 1.01`，可以避免将 1px 也转换成 rem