### PR TITLE
fix: border-radius multiple values

### DIFF
--- a/src/lib/convert.weex.js
+++ b/src/lib/convert.weex.js
@@ -54,17 +54,17 @@ module.exports = function(opts) {
 
                 break;
             case 'border-radius':
-                if (utils.isLength(decl.value)) {
-                    props = createProps(prop, 1);
-                    props.forEach(function(prop) {
-                        decl.cloneBefore({
-                            prop:  prop,
-                            value: decl.value
-                        });
-                    });
+                copyValues(values);
 
-                    decl.remove();
-                }
+                props = createProps(prop, 1);
+                props.forEach(function(prop, i) {
+                    decl.cloneBefore({
+                        prop:  prop,
+                        value: values[i]
+                    });
+                });
+
+                decl.remove();
 
                 break;
             case 'border':


### PR DESCRIPTION
border-radius属性不支持多值设置，当四个角圆弧不一致时会有不同的值设置。如：（`border-radius: 20px 10px 30px 0;`）。原代码里这时是给四个圆角属性都赋值为了该多值，如：`border-top-left-radius: 20px 10px 30px 0;`。此时css属性设置是失效的。在此基础上做了类似margin的处理，把该属性值认定为可能多值，然后分别给四个角设置圆角值。